### PR TITLE
Improved performance of GenerateArrayStrings

### DIFF
--- a/MapFileTools.cs
+++ b/MapFileTools.cs
@@ -4,6 +4,8 @@ using System.IO;
 using static TimberbornTerrainGenerator.Statics;
 using static TimberbornTerrainGenerator.TerrainGen;
 using static TimberbornTerrainGenerator.SettingsUI;
+using System.Text;
+using System.Linq;
 
 namespace TimberbornTerrainGenerator
 {
@@ -89,18 +91,17 @@ namespace TimberbornTerrainGenerator
         }
         public static void GenerateArrayStrings(int[,] map, out string heightMap, out string scalarMap, out string flowMap)
         {
+            var stringBuilder = new StringBuilder();
             heightMap = "";
-            scalarMap = "";
-            flowMap = "";
+            scalarMap = string.Concat(Enumerable.Repeat("0 ", map.Length));
+            flowMap = string.Concat(Enumerable.Repeat("0:0:0:0 ", map.Length)); ;
             int x = 0;
             int y = 0;
             while (y < MapSizeY)
             {
                 while (x < MapSizeX)
                 {
-                    heightMap = heightMap + map[x, y].ToString() + " ";
-                    scalarMap = scalarMap + "0 ";
-                    flowMap = flowMap + "0:0:0:0 ";
+                    stringBuilder.Append(map[x, y].ToString() + " ");
                     y++;
                     if (y == MapSizeY)
                     {
@@ -113,12 +114,14 @@ namespace TimberbornTerrainGenerator
                     }
                 }
             }
+            heightMap = stringBuilder.ToString();
             heightMap = heightMap.Remove(heightMap.Length - 1);
             scalarMap = scalarMap.Remove(scalarMap.Length - 1);
             flowMap = flowMap.Remove(flowMap.Length - 1);
             return;
         }
     }
+
     public class MapFileFormat
     {
         public string GameVersion;


### PR DESCRIPTION
Hello!

With these little changes, the performance of map generation would improve from horrendous to acceptable.

From my testing I found out that MapFileTools.GenerateArrayStrings() is responsible for like 99% of the total time it takes to generate a map. Some stats from my testing
200x200 map:
    Before: 21.26 seconds to create a map
    After: 1.49 seconds to create a map
384x384 map:
    Before: 4 minutes 28 seconds to create a map
    After: 6.02 seconds to create a map

These times do not take into account the loading of the map, just the actual generation.